### PR TITLE
Removed addHeader restrictions because it's allowed

### DIFF
--- a/Message.php
+++ b/Message.php
@@ -230,10 +230,6 @@ class Message
      */
     public function addHeader($key, $value)
     {
-        if (!preg_match('/^X-.*|Reply-To/i', $key)) {
-            throw new \Exception('currently only Reply-To and X-* headers are allowed');
-        }
-
         $this->headers[$key] = $value;
 
         return $this;

--- a/Tests/MessageTest.php
+++ b/Tests/MessageTest.php
@@ -10,7 +10,6 @@ use Hip\MandrillBundle\Message;
  */
 class MessageTest extends \PHPUnit_Framework_TestCase
 {
-
     public function testToIsInitializedAsArray()
     {
         $message = new Message();
@@ -98,20 +97,4 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($headers['X-Binford'], 'more power (9100)');
 
     }
-
-    public function testAddForbiddenHeader()
-    {
-        $message = new Message();
-
-        try {
-            $message->addHeader('Forbidden-Header', 'should fail');
-        } catch (\Exception $e) {
-            return;
-        }
-
-        $this->fail('No exception thrown when trying to set forbidden header');
-    }
-
-
-
 }


### PR DESCRIPTION
It's allowed. I've added some custom headers and they just work :)

Just received this from Mandrill:

```
Hello Ruud,

...
That said, you may set those headers in the headers array without any further action. We'll look at getting the documentation for the accepted headers updated.

Let us know if you have additional questions.

The Mandrill Crew
```
