### PR TITLE
Allow for Symfony 2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
         }
     ],
     "require": {
-        "symfony/http-foundation": ">=2.1,<2.4-dev",
-        "symfony/config": ">=2.1,<2.4-dev",
+        "symfony/http-foundation": ">=2.1,<2.5-dev",
+        "symfony/config": ">=2.1,<2.5-dev",
         "mandrill/mandrill": "1.*"
     },
     "autoload": {
         "psr-0": { "Hip\\MandrillBundle": "" }
     },
     "target-dir": "Hip/MandrillBundle",
-    "minimum-stability": "dev"
+    "minimum-stability": "alpha"
 }


### PR DESCRIPTION
Since [Symfony 2.4.0 Beta 1 is out](http://symfony.com/blog/symfony-2-4-0-beta-1-released) now, I'm bumping the dependencies. Tests works fine and I'll be updating our site to use this in production too.
