### PR TITLE
Add support for the 'type' key on the message recipients array

### DIFF
--- a/Message.php
+++ b/Message.php
@@ -207,12 +207,13 @@ class Message
      *
      * @param string $email
      * @param string $name
+     * @param string $type
      *
      * @return Message
      */
-    public function addTo($email, $name = '')
+    public function addTo($email, $name = '', $type = 'to')
     {
-        $this->to[] = array('email' => $email, 'name' => $name);
+        $this->to[] = array('email' => $email, 'name' => $name, 'type' => $type);
 
         return $this;
     }

--- a/Tests/MessageTest.php
+++ b/Tests/MessageTest.php
@@ -64,6 +64,24 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($recipientArray[1]['name'], 'Foo Bar');
     }
 
+    public function testAddToWithTypes()
+    {
+        $message = new Message();
+        $message->addTo('to-test@example.com', 'Foo Bar');
+        $message->addTo('cc-test@example.com', 'Foo User', 'cc');
+        $message->addTo('bcc-test@example.com', 'Bar User', 'bcc');
+        $recipientArray = $message->getTo();
+
+        $this->assertTrue(is_array($recipientArray));
+        $this->assertEquals(count($recipientArray), 3);
+        $this->assertArrayHasKey('type', $recipientArray[0]);
+        $this->assertEquals($recipientArray[0]['type'], 'to');
+        $this->assertArrayHasKey('type', $recipientArray[1]);
+        $this->assertEquals($recipientArray[1]['type'], 'cc');
+        $this->assertArrayHasKey('type', $recipientArray[2]);
+        $this->assertEquals($recipientArray[2]['type'], 'bcc');
+    }
+
     public function testHeaderIsInitialized()
     {
         $message = new Message();


### PR DESCRIPTION
This allows to add recipients in the CC and BCC fields using the method defined on the Mandrill API
